### PR TITLE
Tidy log space comps

### DIFF
--- a/harmonic/__init__.py
+++ b/harmonic/__init__.py
@@ -1,6 +1,6 @@
 from .chains import Chains
 from . import evidence
-from .evidence import Evidence, Optimisation, Shifting, StatisticSpace
+from .evidence import Evidence, Optimisation, Shifting
 from . import model
 from . import utils
 from . import logs


### PR DESCRIPTION
Logspace statistic computation (along with the StatisticSpace enumerate class) have been archived (tagged) and removed in this pull request. Now the only option is to compute the realspace statistics (with their logspace representations). 