### PR TITLE
Pypi testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@ logs/*.log
 .test.dat
 notebooks/.ipynb_checkpoints/
 notebooks/.temp.*
+.vscode/
 

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     description='Python package for efficient Bayesian evidence computation',
     long_description_content_type = "text/x-rst",
     long_description = long_description,
-    packages=setuptools.find_packages(where='src'),
+    packages=['harmonic'],
     cmdclass={'build_ext': build_ext},
     ext_modules=cythonize([
     Extension(

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
     url='https://github.com/astro-informatics/harmonic',
     author='Jason McEwen & Contributors',
     author_email='jason.mcewen@ucl.ac.uk',
+    license='GNU General Public License v3 (GPLv3)',
     install_requires=required,
     description='Python package for efficient Bayesian evidence computation',
     long_description_content_type = "text/x-rst",

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     ext_modules=cythonize([
     Extension(
         "harmonic.model",
-        package_dir=['src'],
+        package_dir=['harmonic'],
         sources=["harmonic/model.pyx"],
         include_dirs=include_dirs,
         libraries=[],
@@ -64,7 +64,7 @@ setup(
     ),        
     Extension(
         "harmonic.chains",
-        package_dir=['src'],
+        package_dir=['harmonic'],
         sources=["harmonic/chains.pyx"],
         include_dirs=include_dirs,
         libraries=[],
@@ -73,7 +73,7 @@ setup(
     ),
     Extension(
         "harmonic.utils",
-        package_dir=['src'],
+        package_dir=['harmonic'],
         sources=["harmonic/utils.pyx"],
         include_dirs=include_dirs,
         libraries=[],
@@ -82,7 +82,7 @@ setup(
     ),
     Extension(
         "harmonic.logs",
-        package_dir=['src'],
+        package_dir=['harmonic'],
         sources=["harmonic/logs.py"],
         include_dirs=include_dirs,
         libraries=[],
@@ -91,7 +91,7 @@ setup(
     ),
     Extension(
         "harmonic.evidence",
-        package_dir=['src'],
+        package_dir=['harmonic'],
         sources=["harmonic/evidence.pyx"],
         include_dirs=include_dirs,
         libraries=[],


### PR DESCRIPTION
Aims to resolve #182.

Quite basic hotfix for pip not being able to access harmonic submodules.

- added **.vscode/** to .gitignore.
- added license info to `setup.py` setup container
- changed packages to simply 'harmonic' in `setup.py` setup container. This change was inspired by looking at similar repos' setup.py configurations.

Tests this change fixes things:

v1.0.0:
```
python>>> import harmonic as hm
>>> test = hm.Chains(2)
Consolde ouput: ImportError module harmonic has no attribute 'Chains'
```

```
python>>> dir(harmonic)
Consolde ouput:['__doc__', '__file__', '__loader__', '__name__', '__package__', '__path__', '__spec__']
```

After this PR:
```
>>> import harmonic as hm
>>> test=hm.Chains(2)
>>> print(test)
<harmonic.chains.Chains object at 0x7ff0c6b1ce20>
```

```
>>> dir(hm)
['Chains', 'Evidence', 'Shifting', '__builtins__', '__cached__', '__doc__', '__file__', '__loader__', '__name__', '__package__', '__path__', '__spec__', 'chains', 'evidence', 'logs', 'model', 'utils']
```


