### PR TITLE
Add simple python 3.6 compatibility in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,8 @@ include_dirs = [numpy.get_include(),]
 extra_link_args=[]
 
 setup(
-    classifiers=['Programming Language :: Python :: 3.7',
+    classifiers=['Programming Language :: Python :: 3.6',
+                 'Programming Language :: Python :: 3.7',
                  'Programming Language :: Python :: 3.8',
                  'Operating System :: OS Independent',
                  'Intended Audience :: Developers',


### PR DESCRIPTION
@CosmoMatt one-line PR to add explicit python 3.6 compatibility in setup.py for our v1.0.1 pypi yank/patch
Links to #192 (this PR should be merged before v1.0.1 patch)