### PR TITLE
Housekeeping

### DIFF
--- a/.pip_readme.rst
+++ b/.pip_readme.rst
@@ -48,7 +48,7 @@ the non-commercial use condition (see `LICENSE_EXT.txt <https://github.com/astro
 .. code-block::
 
      harmonic
-     Copyright (C) 2021 Jason McEwen & contributors
+     Copyright (C) 2021 Jason D. McEwen, Christopher G. R. Wallis, Matthew A. Price, Matthew M. Docherty & contributors
 
      This program is released under the GPL-3 license (see LICENSE.txt), 
      subject to a non-commercial use condition (see LICENSE_EXT.txt).

--- a/LICENSE_EXT.txt
+++ b/LICENSE_EXT.txt
@@ -14,4 +14,4 @@ Software: harmonic
 
 License: See LICENSE.txt (GPL-3)
 
-Licensor: Jason McEwen & contributors
+Licensor: Jason D. McEwen, Christopher G. R. Wallis, Matthew A. Price, Matthew M. Docherty & contributors

--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ See comprehensive documentation at `Harmonic Documentation <https://astro-inform
 Contributors
 ------------
 
-`Jason McEwen <http://www.jasonmcewen.org/>`_, `Christopher Wallis <https://scholar.google.co.uk/citations?user=Igl7nakAAAAJ&hl=en>`_, `Matthew Price <https://scholar.google.co.uk/citations?user=w7_VDLQAAAAJ&hl=en&authuser=1>`_, `Matthew Docherty <https://mdochertyastro.com/>`_
+`Jason D. McEwen <http://www.jasonmcewen.org/>`_, `Christopher G. R. Wallis <https://scholar.google.co.uk/citations?user=Igl7nakAAAAJ&hl=en>`_, `Matthew A. Price <https://scholar.google.co.uk/citations?user=w7_VDLQAAAAJ&hl=en&authuser=1>`_, `Matthew M. Docherty <https://mdochertyastro.com/>`_
 
 Attribution
 -----------
@@ -55,7 +55,7 @@ the non-commercial use condition (see `LICENSE_EXT.txt <https://github.com/astro
 .. code-block::
 
      harmonic
-     Copyright (C) 2021 Jason McEwen, Christopher Wallis, Matthew Price, Matthew Docherty & contributors
+     Copyright (C) 2021 Jason D. McEwen, Christopher G. R. Wallis, Matthew A. Price, Matthew M. Docherty & contributors
 
      This program is released under the GPL-3 license (see LICENSE.txt), 
      subject to a non-commercial use condition (see LICENSE_EXT.txt).

--- a/README.rst
+++ b/README.rst
@@ -5,8 +5,6 @@
 
    <img src="./docs/assets/harm_badge_simple.svg" align="center" height="52" width="52">
 
-.. image:: https://img.shields.io/badge/GitHub-harmonic-brightgreen.svg?style=flat
-    :target: https://github.com/astro-informatics/harmonic
 .. image:: https://github.com/astro-informatics/harmonic/actions/workflows/python.yml/badge.svg
     :target: https://github.com/astro-informatics/harmonic/actions/workflows/python.yml
 .. image:: https://codecov.io/gh/astro-informatics/harmonic/branch/main/graph/badge.svg?token=1s4SATphHV
@@ -17,8 +15,10 @@
     :target: http://perso.crans.org/besson/LICENSE.html
 .. image:: https://readthedocs.org/projects/ansicolortags/badge/?version=latest
     :target: https://astro-informatics.github.io/harmonic/
-.. image:: https://badge.fury.io/py/ansicolortags.svg
-    :target: https://pypi.python.org/pypi/harmonic/
+.. image:: https://badge.fury.io/py/harmonic.svg
+    :target: https://badge.fury.io/py/harmonic
+.. image:: https://img.shields.io/pypi/pyversions/harmonic.svg
+    :target: https://pypi.python.org/pypi/harmonic/)
 
 ``harmonic`` is an open source and fully documented python implementation of the Learnt Harmonic Mean estimator for the 
 Bayesian evidence or marginal likelihood. In practice one uses chains gathered separately through MCMC sampling software 

--- a/README.rst
+++ b/README.rst
@@ -5,6 +5,8 @@
 
    <img src="./docs/assets/harm_badge_simple.svg" align="center" height="52" width="52">
 
+.. image:: https://img.shields.io/badge/GitHub-harmonic-brightgreen.svg?style=flat
+    :target: https://github.com/astro-informatics/harmonic
 .. image:: https://github.com/astro-informatics/harmonic/actions/workflows/python.yml/badge.svg
     :target: https://github.com/astro-informatics/harmonic/actions/workflows/python.yml
 .. image:: https://codecov.io/gh/astro-informatics/harmonic/branch/main/graph/badge.svg?token=1s4SATphHV

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@
 .. image:: https://img.shields.io/badge/License-GPL-blue.svg
     :target: http://perso.crans.org/besson/LICENSE.html
 
-Harmonic is an open source and fully documented python implementation of the Learnt Harmonic Mean estimator for the 
+``harmonic`` is an open source and fully documented python implementation of the Learnt Harmonic Mean estimator for the 
 Bayesian evidence or marginal likelihood. In practice one uses chains gathered separately through MCMC sampling software 
 to train one of the Harmonic machine learning models which then stabilize the harmonic mean estimator.
 
@@ -49,13 +49,13 @@ shortly upon submission. A BibTeX entry for the paper is:
 License
 -------
 
-Harmonic is released under the GPL-3 license (see `LICENSE.txt <https://github.com/astro-informatics/harmonic/blob/main/LICENSE.txt>`_), subject to 
+``harmonic`` is released under the GPL-3 license (see `LICENSE.txt <https://github.com/astro-informatics/harmonic/blob/main/LICENSE.txt>`_), subject to 
 the non-commercial use condition (see `LICENSE_EXT.txt <https://github.com/astro-informatics/harmonic/blob/main/LICENSE_EXT.txt>`_)
 
 .. code-block::
 
      harmonic
-     Copyright (C) 2021 Jason McEwen & contributors
+     Copyright (C) 2021 Jason McEwen, Christopher Wallis, Matthew Price, Matthew Docherty & contributors
 
      This program is released under the GPL-3 license (see LICENSE.txt), 
      subject to a non-commercial use condition (see LICENSE_EXT.txt).

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@
 .. image:: https://badge.fury.io/py/harmonic.svg
     :target: https://badge.fury.io/py/harmonic
 .. image:: https://img.shields.io/pypi/pyversions/harmonic.svg
-    :target: https://pypi.python.org/pypi/harmonic/)
+    :target: https://pypi.python.org/pypi/harmonic/
 
 ``harmonic`` is an open source and fully documented python implementation of the Learnt Harmonic Mean estimator for the 
 Bayesian evidence or marginal likelihood. In practice one uses chains gathered separately through MCMC sampling software 

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,9 @@
 .. image:: https://img.shields.io/badge/License-GPL-blue.svg
     :target: http://perso.crans.org/besson/LICENSE.html
 .. image:: https://readthedocs.org/projects/ansicolortags/badge/?version=latest
-    :target: http://perso.crans.org/besson/LICENSE.html
+    :target: https://astro-informatics.github.io/harmonic/
+.. image:: https://badge.fury.io/py/ansicolortags.svg
+    :target: https://pypi.python.org/pypi/harmonic/
 
 ``harmonic`` is an open source and fully documented python implementation of the Learnt Harmonic Mean estimator for the 
 Bayesian evidence or marginal likelihood. In practice one uses chains gathered separately through MCMC sampling software 

--- a/README.rst
+++ b/README.rst
@@ -19,8 +19,8 @@
     :target: https://astro-informatics.github.io/harmonic/
 .. image:: https://badge.fury.io/py/harmonic.svg
     :target: https://badge.fury.io/py/harmonic
-.. image:: https://img.shields.io/pypi/pyversions/harmonic.svg
-    :target: https://pypi.python.org/pypi/harmonic/
+.. .. image:: https://img.shields.io/pypi/pyversions/harmonic.svg
+..     :target: https://pypi.python.org/pypi/harmonic/
 
 ``harmonic`` is an open source and fully documented python implementation of the Learnt Harmonic Mean estimator for the 
 Bayesian evidence or marginal likelihood. In practice one uses chains gathered separately through MCMC sampling software 

--- a/README.rst
+++ b/README.rst
@@ -15,6 +15,8 @@
     :target: https://arxiv.org/abs/20XX.XXXXX
 .. image:: https://img.shields.io/badge/License-GPL-blue.svg
     :target: http://perso.crans.org/besson/LICENSE.html
+.. image:: https://readthedocs.org/projects/ansicolortags/badge/?version=latest
+    :target: http://perso.crans.org/besson/LICENSE.html
 
 ``harmonic`` is an open source and fully documented python implementation of the Learnt Harmonic Mean estimator for the 
 Bayesian evidence or marginal likelihood. In practice one uses chains gathered separately through MCMC sampling software 

--- a/README.rst
+++ b/README.rst
@@ -1,10 +1,3 @@
-|logo| Harmonic
-=================================================================================================================
-
-.. |logo| raw:: html
-
-   <img src="./docs/assets/harm_badge_simple.svg" align="center" height="52" width="52">
-
 .. image:: https://img.shields.io/badge/GitHub-harmonic-brightgreen.svg?style=flat
     :target: https://github.com/astro-informatics/harmonic
 .. image:: https://github.com/astro-informatics/harmonic/actions/workflows/python.yml/badge.svg
@@ -21,6 +14,13 @@
     :target: https://badge.fury.io/py/harmonic
 .. .. image:: https://img.shields.io/pypi/pyversions/harmonic.svg
 ..     :target: https://pypi.python.org/pypi/harmonic/
+
+|logo| Harmonic
+=================================================================================================================
+
+.. |logo| raw:: html
+
+   <img src="./docs/assets/harm_badge_simple.svg" align="center" height="52" width="52">
 
 ``harmonic`` is an open source and fully documented python implementation of the Learnt Harmonic Mean estimator for the 
 Bayesian evidence or marginal likelihood. In practice one uses chains gathered separately through MCMC sampling software 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,8 +20,8 @@ sys.path.insert(0, os.path.abspath('..'))
 # -- Project information -----------------------------------------------------
 
 project = 'Harmonic'
-copyright = '2021, Jason D. McEwen, Christopher G. R. Wallis, Matthew A. Price'
-author = 'Jason D. McEwen, Christopher G. R. Wallis, Matthew A. Price'
+copyright = '2021, Jason D. McEwen, Christopher G. R. Wallis, Matthew A. Price, Matthew M. Docherty'
+author = 'Jason D. McEwen, Christopher G. R. Wallis, Matthew A. Price, Matthew M. Docherty'
 
 # The short X.Y version
 version = '1.0.1'
@@ -170,7 +170,7 @@ latex_elements = {
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
     (master_doc, 'Harmonic.tex', 'Harmonic Documentation',
-     'Jason D. McEwen, Christopher G. R. Wallis, Matthew A. Price', 'manual'),
+     'Jason D. McEwen, Christopher G. R. Wallis, Matthew A. Price, Matthew M. Docherty', 'manual'),
 ]
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 Harmonic
 ========
 
-|GitHub| |Build Status| |CodeCov| |ArXiv| |GPL license|
+|GitHub| |Build Status| |CodeCov| |ArXiv| |GPL license| |Docs| |PyPI|
 
 .. |GitHub| image:: https://img.shields.io/badge/GitHub-harmonic-brightgreen.svg?style=flat
    :target: https://github.com/astro-informatics/harmonic
@@ -17,6 +17,12 @@ Harmonic
 
 .. |GPL license| image:: https://img.shields.io/badge/License-GPL-blue.svg
    :target: http://perso.crans.org/besson/LICENSE.html
+
+.. |Docs| image:: https://readthedocs.org/projects/ansicolortags/badge/?version=latest
+   :target: https://astro-informatics.github.io/harmonic/
+
+.. |PyPI| image:: https://badge.fury.io/py/harmonic.svg
+   :target: https://badge.fury.io/py/harmonic
 
 The harmonic mean is an infamous estimator for the Bayesian evidence, first proposed by `Newton and Raftery (1994)  <https://rss.onlinelibrary.wiley.com/doi/pdf/10.1111/j.2517-6161.1994.tb01956.x>`_. Whilst the harmonic mean estimator is asymptotically consistent it can fail catastrophically, depending on how one configures the estimator. By integrating bespoke machine learning techniques, **Harmonic** overcomes this hurdle by learning from disperate samples of the posterior. Our learnt estimator is agnostic to the sampler, provides accurate estimates of the variance and variance in the variance, and can scale into thousands of dimensions.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,6 +1,3 @@
-Harmonic
-========
-
 |GitHub| |Build Status| |CodeCov| |ArXiv| |GPL license| |Docs| |PyPI|
 
 .. |GitHub| image:: https://img.shields.io/badge/GitHub-harmonic-brightgreen.svg?style=flat
@@ -23,6 +20,9 @@ Harmonic
 
 .. |PyPI| image:: https://badge.fury.io/py/harmonic.svg
    :target: https://badge.fury.io/py/harmonic
+
+Harmonic
+========
 
 The harmonic mean is an infamous estimator for the Bayesian evidence, first proposed by `Newton and Raftery (1994)  <https://rss.onlinelibrary.wiley.com/doi/pdf/10.1111/j.2517-6161.1994.tb01956.x>`_. Whilst the harmonic mean estimator is asymptotically consistent it can fail catastrophically, depending on how one configures the estimator. By integrating bespoke machine learning techniques, **Harmonic** overcomes this hurdle by learning from disperate samples of the posterior. Our learnt estimator is agnostic to the sampler, provides accurate estimates of the variance and variance in the variance, and can scale into thousands of dimensions.
 

--- a/examples/gaussian_nondiagcov.py
+++ b/examples/gaussian_nondiagcov.py
@@ -108,7 +108,7 @@ def run_example(ndim=2, nchains=100, samples_per_chain=1000,
         
         if n_realisations > 0:
             hm.logs.info_log('Realisation = {}/{}'
-                .format(i_realisation, n_realisations))
+                .format(i_realisation+1, n_realisations))
 
         # Set up and run sampler.
         hm.logs.info_log('Run sampling...')

--- a/examples/rastrigin.py
+++ b/examples/rastrigin.py
@@ -150,7 +150,7 @@ def run_example(ndim=2, nchains=100, samples_per_chain=1000,
 
         if n_realisations > 1:
             hm.logs.info_log('Realisation number = {}/{}'
-                .format(i_realisation, n_realisations))
+                .format(i_realisation+1, n_realisations))
     
         #=======================================================================
         # Run Emcee to recover posterior samples

--- a/examples/rosenbrock.py
+++ b/examples/rosenbrock.py
@@ -186,7 +186,7 @@ def run_example(ndim=2, nchains=100, samples_per_chain=1000,
 
         if n_realisations > 1:
             hm.logs.info_log('Realisation number = {}/{}'
-                .format(i_realisation, n_realisations))
+                .format(i_realisation+1, n_realisations))
         
         #=======================================================================
         # Run Emcee to recover posterior samples 

--- a/requirements/requirements-core.txt
+++ b/requirements/requirements-core.txt
@@ -5,4 +5,4 @@ jupyter==1.0.0
 scikit-learn==0.22.2.post1
 scipy==1.4.1
 colorlog==4.1.0
-pyyaml==3.12
+pyyaml==5.4

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     version = "1.0.1",
     prefix='.',
     url='https://github.com/astro-informatics/harmonic',
-    author='Jason McEwen & Contributors',
+    author='Jason D. McEwen, Christopher G. R. Wallis, Matthew A. Price, Matthew M. Docherty & Contributors',
     author_email='jason.mcewen@ucl.ac.uk',
     license='GNU General Public License v3 (GPLv3)',
     install_requires=required,

--- a/temp/basic_usage.nblink
+++ b/temp/basic_usage.nblink
@@ -1,3 +1,0 @@
-{
-    "path": "../../notebooks/basic_usage.ipynb"
-}

--- a/temp/checkpointing.nblink
+++ b/temp/checkpointing.nblink
@@ -1,3 +1,0 @@
-{
-    "path": "../../notebooks/checkpointing.ipynb"
-}

--- a/temp/cross-validation_hyper-parameters.nblink
+++ b/temp/cross-validation_hyper-parameters.nblink
@@ -1,3 +1,0 @@
-{
-    "path": "../../notebooks/cross-validation_hyper-parameters.ipynb"
-}

--- a/temp/cross-validation_learnt_model.nblink
+++ b/temp/cross-validation_learnt_model.nblink
@@ -1,3 +1,0 @@
-{
-    "path": "../../notebooks/cross-validation_learnt_model.ipynb"
-}


### PR DESCRIPTION
Links with issue #187.

- Changed Harmonic to `harmonic` in readme
- Added full contributor list to all license and project authorship throughout repo
- Removed github badge from readme
- Added 2 Pypi badges to readme
- Removed `temp/` dir.
- Started i_realisation on 1 in 3 example scripts

@CosmoMatt could you have a look over this whenever you can (and please correct me if `temp/` is not as redundant as I'm thinking it is.

As this PR alters the license/authors wrt Pypi & `setup.py` I would like to merge this and PR #193 before we re-deploy v1.0.1
