### PR TITLE
Update pinned version of matplotlib

### DIFF
--- a/requirements/requirements-examples.txt
+++ b/requirements/requirements-examples.txt
@@ -1,4 +1,4 @@
 emcee==3.1.4
-matplotlib==3.2.1
+matplotlib==3.7.2
 corner==2.0.1
 getdist==1.4.3


### PR DESCRIPTION
Previous pinned version caused a segfault when running examples.