### PR TITLE
remove non-log class variables and their use in examples

### DIFF
--- a/examples/legacy_gaussian_diagcov.py
+++ b/examples/legacy_gaussian_diagcov.py
@@ -216,18 +216,18 @@ def run_example(
     hm.logs.debug_log("---------------------------------")
     hm.logs.debug_log(
         "Inv Evidence: analytic = {}, estimate = {}".format(
-            np.exp(ln_rho), cal_ev.evidence_inv
+            np.exp(ln_rho), np.exp(cal_ev.ln_evidence_inv)
         )
     )
     hm.logs.debug_log(
         "Inv Evidence: std = {}, std / estimate = {}".format(
-            np.sqrt(cal_ev.evidence_inv_var),
-            np.sqrt(cal_ev.evidence_inv_var) / cal_ev.evidence_inv,
+            np.sqrt(np.exp(cal_ev.ln_evidence_inv_var)),
+            np.sqrt(np.exp(cal_ev.ln_evidence_inv_var)) / np.exp(cal_ev.ln_evidence_inv),
         )
     )
     hm.logs.info_log(
         "Inv Evidence: 100 * |analytic - estimate| / estimate = {}%".format(
-            100.0 * np.abs(np.exp(ln_rho) - cal_ev.evidence_inv) / cal_ev.evidence_inv
+            100.0 * np.abs(np.exp(ln_rho) - np.exp(cal_ev.ln_evidence_inv)) / np.exp(cal_ev.ln_evidence_inv)
         )
     )
 

--- a/examples/legacy_gaussian_nondiagcov.py
+++ b/examples/legacy_gaussian_nondiagcov.py
@@ -186,13 +186,13 @@ def run_example(
         hm.logs.debug_log("---------------------------------")
         hm.logs.debug_log(
             "Inv Evidence: analytic = {}, estimate = {}".format(
-                np.exp(-ln_evidence_analytic), ev.evidence_inv
+                np.exp(-ln_evidence_analytic), np.exp(ev.ln_evidence_inv)
             )
         )
         hm.logs.debug_log(
             "Inv Evidence: std = {}, std / estimate = {}".format(
-                np.sqrt(ev.evidence_inv_var),
-                np.sqrt(ev.evidence_inv_var) / ev.evidence_inv,
+                np.sqrt(np.exp(ev.ln_evidence_inv_var)),
+                np.sqrt(np.exp(ev.ln_evidence_inv_var)) / np.exp(ev.ln_evidence_inv),
             )
         )
         hm.logs.debug_log(
@@ -202,13 +202,13 @@ def run_example(
         )
         hm.logs.debug_log(
             "Inv Evidence: sqrt( var(var) ) / var = {}".format(
-                np.sqrt(ev.evidence_inv_var_var) / ev.evidence_inv_var
+                np.sqrt(np.exp(ev.ln_evidence_inv_var_var)) / np.exp(ev.ln_evidence_inv_var)
             )
         )
         hm.logs.info_log(
             "Inv Evidence: |analytic - estimate| / estimate = {}".format(
-                np.abs(np.exp(-ln_evidence_analytic) - ev.evidence_inv)
-                / ev.evidence_inv
+                np.abs(np.exp(-ln_evidence_analytic) - np.exp(ev.ln_evidence_inv))
+                / np.exp(ev.ln_evidence_inv)
             )
         )
 
@@ -375,9 +375,9 @@ def run_example(
             plt.show(block=False)
             # ==================================================================
 
-        evidence_inv_summary[i_realisation, 0] = ev.evidence_inv
-        evidence_inv_summary[i_realisation, 1] = ev.evidence_inv_var
-        evidence_inv_summary[i_realisation, 2] = ev.evidence_inv_var_var
+        evidence_inv_summary[i_realisation, 0] = np.exp(ev.ln_evidence_inv)
+        evidence_inv_summary[i_realisation, 1] = np.exp(ev.ln_evidence_inv_var)
+        evidence_inv_summary[i_realisation, 2] = np.exp(ev.ln_evidence_inv_var_var)
 
     clock = time.process_time() - clock
     hm.logs.info_log("Execution_time = {}s".format(clock))

--- a/examples/legacy_rastrigin.py
+++ b/examples/legacy_rastrigin.py
@@ -270,13 +270,13 @@ def run_example(
         # ======================================================================
         hm.logs.debug_log(
             "Inv Evidence: numerical = {}, estimate = {}".format(
-                1.0 / evidence_numerical_integration, ev.evidence_inv
+                1.0 / evidence_numerical_integration, np.exp(ev.ln_evidence_inv)
             )
         )
         hm.logs.debug_log(
             "Inv Evidence: std = {}, std / estimate = {}".format(
-                np.sqrt(ev.evidence_inv_var),
-                np.sqrt(ev.evidence_inv_var) / ev.evidence_inv,
+                np.sqrt(np.exp(ev.ln_evidence_inv_var)),
+                np.sqrt(np.exp(ev.ln_evidence_inv_var)) / np.exp(ev.ln_evidence_inv),
             )
         )
         hm.logs.debug_log(
@@ -286,13 +286,13 @@ def run_example(
         )
         hm.logs.debug_log(
             "Inv Evidence: sqrt( var(var) )/ var = {}".format(
-                np.sqrt(ev.evidence_inv_var_var) / ev.evidence_inv_var
+                np.sqrt(np.exp(ev.ln_evidence_inv_var_var)) / np.exp(ev.ln_evidence_inv_var)
             )
         )
         hm.logs.info_log(
             "Inv Evidence: |numerical - estimate| / estimate = {}".format(
-                np.abs(1.0 / evidence_numerical_integration - ev.evidence_inv)
-                / ev.evidence_inv
+                np.abs(1.0 / evidence_numerical_integration - np.exp(ev.ln_evidence_inv))
+                / np.exp(ev.ln_evidence_inv)
             )
         )
 
@@ -409,9 +409,9 @@ def run_example(
                 created_plots = True
 
         # Save out realisations for voilin plot.
-        evidence_inv_summary[i_realisation, 0] = ev.evidence_inv
-        evidence_inv_summary[i_realisation, 1] = ev.evidence_inv_var
-        evidence_inv_summary[i_realisation, 2] = ev.evidence_inv_var_var
+        evidence_inv_summary[i_realisation, 0] = np.exp(ev.ln_evidence_inv)
+        evidence_inv_summary[i_realisation, 1] = np.exp(ev.ln_evidence_inv_var)
+        evidence_inv_summary[i_realisation, 2] = np.exp(ev.ln_evidence_inv_var_var)
 
     # ===========================================================================
     # End Timer.

--- a/examples/legacy_rosenbrock.py
+++ b/examples/legacy_rosenbrock.py
@@ -308,13 +308,13 @@ def run_example(
         # ======================================================================
         hm.logs.debug_log(
             "Inv Evidence: numerical = {}, estimate = {}".format(
-                1.0 / evidence_numerical_integration, ev.evidence_inv
+                1.0 / evidence_numerical_integration, np.exp(ev.ln_evidence_inv)
             )
         )
         hm.logs.debug_log(
             "Inv Evidence: std = {}, std / estimate = {}".format(
-                np.sqrt(ev.evidence_inv_var),
-                np.sqrt(ev.evidence_inv_var) / ev.evidence_inv,
+                np.sqrt(np.exp(ev.ln_evidence_inv_var)),
+                np.sqrt(np.exp(ev.ln_evidence_inv_var)) / np.exp(ev.ln_evidence_inv),
             )
         )
         hm.logs.debug_log(
@@ -324,13 +324,13 @@ def run_example(
         )
         hm.logs.debug_log(
             "Inv Evidence: sqrt( var(var) )/ var = {}".format(
-                np.sqrt(ev.evidence_inv_var_var) / ev.evidence_inv_var
+                np.sqrt(np.exp(ev.ln_evidence_inv_var_var)) / np.exp(ev.ln_evidence_inv_var)
             )
         )
         hm.logs.info_log(
             "Inv Evidence: |numerical - estimate| / estimate = {}".format(
-                np.abs(1.0 / evidence_numerical_integration - ev.evidence_inv)
-                / ev.evidence_inv
+                np.abs(1.0 / evidence_numerical_integration - np.exp(ev.ln_evidence_inv))
+                / np.exp(ev.ln_evidence_inv)
             )
         )
 
@@ -449,9 +449,9 @@ def run_example(
             created_plots = True
 
         # Save out realisations for voilin plot.
-        evidence_inv_summary[i_realisation, 0] = ev.evidence_inv
-        evidence_inv_summary[i_realisation, 1] = ev.evidence_inv_var
-        evidence_inv_summary[i_realisation, 2] = ev.evidence_inv_var_var
+        evidence_inv_summary[i_realisation, 0] = np.exp(ev.ln_evidence_inv)
+        evidence_inv_summary[i_realisation, 1] = np.exp(ev.ln_evidence_inv_var)
+        evidence_inv_summary[i_realisation, 2] = np.exp(ev.ln_evidence_inv_var_var)
 
     # ===========================================================================
     # End Timer.

--- a/harmonic/evidence.py
+++ b/harmonic/evidence.py
@@ -424,7 +424,7 @@ class Evidence:
         evidence_inv = np.exp(self.ln_evidence_inv)
         evidence_inv_var = np.exp(self.ln_evidence_inv_var)
 
-        if np.isnan(evidence_inv) or np.isnan(evidence_inv_var):
+        if np.isinf(np.nan_to_num(evidence_inv, nan=np.inf)) or np.isinf(np.nan_to_num(evidence_inv_var, nan=np.inf)):
             raise ValueError("Evidence is too large to represent in non-log space. Use log-space values instead.")
 
         common_factor = 1.0 + evidence_inv_var / (evidence_inv**2)
@@ -574,9 +574,9 @@ def compute_bayes_factor(ev1, ev2):
     evidence_inv_ev2 = np.exp(ev2.ln_evidence_inv)
     evidence_inv_var_ev2 = np.exp(ev2.ln_evidence_inv_var)
 
-    if np.isnan(evidence_inv_ev1) or np.isnan(evidence_inv_var_ev1):
+    if np.isinf(np.nan_to_num(evidence_inv_ev1, nan=np.inf)) or np.isinf(np.nan_to_num(evidence_inv_var_ev1, nan=np.inf)):
         raise ValueError("Evidence for model 1 is too large to represent in non-log space. Use log-space values instead.")
-    if np.isnan(evidence_inv_ev2) or np.isnan(evidence_inv_var_ev2):
+    if np.isinf(np.nan_to_num(evidence_inv_ev2, nan=np.inf)) or np.isinf(np.nan_to_num(evidence_inv_var_ev2, nan=np.inf)):
         raise ValueError("Evidence for model 2 is too large to represent in non-log space. Use log-space values instead.")
 
     common_factor = 1.0 + evidence_inv_var_ev1 / (evidence_inv_ev1**2)


### PR DESCRIPTION
This removes any class variables which attempt to explicitly store non-log space evidence. These values can, of course, still be accessed by exponentiating the log evidence.