### PR TITLE
Clarify prior docstring description.

### DIFF
--- a/examples/rosenbrock.py
+++ b/examples/rosenbrock.py
@@ -7,7 +7,7 @@ import harmonic as hm
 
 
 def ln_prior_uniform(x, xmin=-10.0, xmax=10.0, ymin=-5.0, ymax=15.0):
-    """Compute log_e of uniform prior.
+    """Compute log_e uniform prior.
 
     Args:
 


### PR DESCRIPTION
Clarify docstring for function computing prior in Rosenbrock example to underline the prior is uniform in log space.