### PR TITLE
Add batching of evidence estimation inputs and update examples

### DIFF
--- a/examples/gaussian_nondiagcov.py
+++ b/examples/gaussian_nondiagcov.py
@@ -198,56 +198,33 @@ def run_example(
         if i_realisation == 0:
             ln_evidence_analytic = ln_analytic_evidence(ndim, cov)
 
-        # ======================================================================
-        # Display evidence computation results.
-        # ======================================================================
         hm.logs.info_log("---------------------------------")
+        hm.logs.info_log("The inverse evidence in log space is:")
         hm.logs.info_log(
-            "Evidence: analytic = {}, estimated = {}".format(
-                np.exp(ln_evidence_analytic), np.exp(ln_evidence)
-            )
-        )
-        hm.logs.info_log(
-            "Evidence: std = {}, std / estimate = {}".format(
-                np.exp(ln_evidence_std), np.exp(ln_evidence_std - ln_evidence)
-            )
-        )
-        diff = np.log(np.abs(np.exp(ln_evidence_analytic) - np.exp(ln_evidence)))
-        hm.logs.info_log(
-            "Evidence: |analytic - estimate| / estimate = {}".format(
-                np.exp(diff - ln_evidence)
-            )
-        )
-        # ======================================================================
-        # Display inverse evidence computation results.
-        # ======================================================================
-        hm.logs.debug_log("---------------------------------")
-        hm.logs.debug_log(
-            "Inv Evidence: analytic = {}, estimate = {}".format(
-                np.exp(-ln_evidence_analytic), ev.evidence_inv
-            )
-        )
-        hm.logs.debug_log(
-            "Inv Evidence: std = {}, std / estimate = {}".format(
-                np.sqrt(ev.evidence_inv_var),
-                np.sqrt(ev.evidence_inv_var) / ev.evidence_inv,
-            )
-        )
-        hm.logs.debug_log(
-            "Inv Evidence: kurtosis = {}, sqrt( 2 / ( n_eff - 1 ) ) = {}".format(
-                ev.kurtosis, np.sqrt(2.0 / (ev.n_eff - 1))
-            )
-        )
-        hm.logs.debug_log(
-            "Inv Evidence: sqrt( var(var) ) / var = {}".format(
-                np.sqrt(ev.evidence_inv_var_var) / ev.evidence_inv_var
+            "ln_inv_evidence = {} +/- {}".format(
+                ev.ln_evidence_inv, err_ln_inv_evidence
             )
         )
         hm.logs.info_log(
-            "Inv Evidence: |analytic - estimate| / estimate = {}".format(
-                np.abs(np.exp(-ln_evidence_analytic) - ev.evidence_inv)
-                / ev.evidence_inv
+            "ln evidence = {} +/- {} {}".format(
+                -ev.ln_evidence_inv, -err_ln_inv_evidence[1], -err_ln_inv_evidence[0]
             )
+        )
+        hm.logs.info_log("Analytic ln evidence is ", ln_evidence_analytic)
+        delta = -ln_evidence_analytic - ev.ln_evidence_inv
+        hm.logs.info_log(
+            "Difference between analytic and harmonic  is ",
+            delta,
+            "+/-",
+            err_ln_inv_evidence[0],
+            err_ln_inv_evidence[1],
+        )
+
+        hm.logs.debug_log("kurtosis = {}".format(ev.kurtosis), " Aim for ~3.")
+        check = np.exp(0.5 * ev.ln_evidence_inv_var_var - ev.ln_evidence_inv_var)
+        hm.logs.debug_log("sqrt( var(var) ) / var = = {}".format(check))
+        hm.logs.debug_log(
+            " Aim for sqrt( 2/(n_eff-1) ) = {}".format(np.sqrt(2.0 / (ev.n_eff - 1)))
         )
 
         # ===========================================================================

--- a/examples/gaussian_nondiagcov.py
+++ b/examples/gaussian_nondiagcov.py
@@ -102,7 +102,7 @@ def run_example(
         epochs_num = 5
     elif flow_type == "RQSpline":
         # epochs_num = 3
-        epochs_num = 100
+        epochs_num = 10
 
     # Beginning of path where plots will be saved
     save_name_start = "examples/plots/" + flow_type
@@ -210,19 +210,17 @@ def run_example(
                 -ev.ln_evidence_inv, -err_ln_inv_evidence[1], -err_ln_inv_evidence[0]
             )
         )
-        hm.logs.info_log("Analytic ln evidence is ", ln_evidence_analytic)
+        hm.logs.info_log("Analytic ln evidence is {}".format(ln_evidence_analytic))
         delta = -ln_evidence_analytic - ev.ln_evidence_inv
         hm.logs.info_log(
-            "Difference between analytic and harmonic  is ",
-            delta,
-            "+/-",
-            err_ln_inv_evidence[0],
-            err_ln_inv_evidence[1],
+            "Difference between analytic and harmonic  is {} +- {} {}".format(
+                delta, err_ln_inv_evidence[0], err_ln_inv_evidence[1]
+            )
         )
 
         hm.logs.debug_log("kurtosis = {}".format(ev.kurtosis), " Aim for ~3.")
         check = np.exp(0.5 * ev.ln_evidence_inv_var_var - ev.ln_evidence_inv_var)
-        hm.logs.debug_log("sqrt( var(var) ) / var = = {}".format(check))
+        hm.logs.debug_log("sqrt( var(var) ) / var = {}".format(check))
         hm.logs.debug_log(
             " Aim for sqrt( 2/(n_eff-1) ) = {}".format(np.sqrt(2.0 / (ev.n_eff - 1)))
         )

--- a/examples/gaussian_nondiagcov.py
+++ b/examples/gaussian_nondiagcov.py
@@ -101,7 +101,8 @@ def run_example(
     if flow_type == "RealNVP":
         epochs_num = 5
     elif flow_type == "RQSpline":
-        epochs_num = 3
+        # epochs_num = 3
+        epochs_num = 100
 
     # Beginning of path where plots will be saved
     save_name_start = "examples/plots/" + flow_type
@@ -112,7 +113,7 @@ def run_example(
 
     # Spline params
     n_layers = 5
-    n_bins = 5
+    n_bins = 16
     hidden_size = [32, 32]
     spline_range = (-10.0, 10.0)
 
@@ -314,6 +315,7 @@ def run_example(
 
             plt.show()
 
+        # Save out realisations for violin plot.
         evidence_inv_summary[i_realisation, 0] = ev.evidence_inv
         evidence_inv_summary[i_realisation, 1] = ev.evidence_inv_var
         evidence_inv_summary[i_realisation, 2] = ev.evidence_inv_var_var
@@ -347,11 +349,11 @@ if __name__ == "__main__":
     hm.logs.setup_logging()
 
     # Define parameters.
-    ndim = 5
+    ndim = 21
     nchains = 100
     samples_per_chain = 5000
-    flow_str = "RealNVP"
-    # flow_str = "RQSpline"
+    # flow_str = "RealNVP"
+    flow_str = "RQSpline"
     np.random.seed(10)  # used for initializing covariance matrix
 
     hm.logs.info_log("Non-diagonal Covariance Gaussian example")

--- a/examples/gaussian_nondiagcov.py
+++ b/examples/gaussian_nondiagcov.py
@@ -218,7 +218,8 @@ def run_example(
             )
         )
 
-        hm.logs.debug_log("kurtosis = {}".format(ev.kurtosis), " Aim for ~3.")
+        hm.logs.debug_log("kurtosis = {}".format(ev.kurtosis))
+        hm.logs.debug_log(" Aim for ~3.")
         check = np.exp(0.5 * ev.ln_evidence_inv_var_var - ev.ln_evidence_inv_var)
         hm.logs.debug_log("sqrt( var(var) ) / var = {}".format(check))
         hm.logs.debug_log(

--- a/examples/gaussian_nondiagcov.py
+++ b/examples/gaussian_nondiagcov.py
@@ -192,7 +192,7 @@ def run_example(
         ev = hm.Evidence(chains_test.nchains, model)
         # ev.set_mean_shift(0.0)
         ev.add_chains(chains_test)
-        ln_evidence, ln_evidence_std = ev.compute_ln_evidence()
+        err_ln_inv_evidence = ev.compute_ln_inv_evidence_errors()
 
         # Compute analytic evidence.
         if i_realisation == 0:

--- a/examples/gaussian_nondiagcov.py
+++ b/examples/gaussian_nondiagcov.py
@@ -122,7 +122,7 @@ def run_example(
 
     # Run multiple realisations.
     n_realisations = 1
-    evidence_inv_summary = np.zeros((n_realisations, 3))
+    ln_evidence_inv_summary = np.zeros((n_realisations, 3))
     for i_realisation in range(n_realisations):
         if n_realisations > 0:
             hm.logs.info_log(
@@ -292,9 +292,9 @@ def run_example(
             plt.show()
 
         # Save out realisations for violin plot.
-        evidence_inv_summary[i_realisation, 0] = ev.evidence_inv
-        evidence_inv_summary[i_realisation, 1] = ev.evidence_inv_var
-        evidence_inv_summary[i_realisation, 2] = ev.evidence_inv_var_var
+        ln_evidence_inv_summary[i_realisation, 0] = ev.ln_evidence_inv
+        ln_evidence_inv_summary[i_realisation, 1] = ev.ln_evidence_inv_var
+        ln_evidence_inv_summary[i_realisation, 2] = ev.ln_evidence_inv_var_var
 
     clock = time.process_time() - clock
     hm.logs.info_log("Execution_time = {}s".format(clock))
@@ -302,18 +302,18 @@ def run_example(
     if n_realisations > 1:
         save_name = (
             save_name_start
-            + "_gaussian_nondiagcov_evidence_inv"
+            + "_gaussian_nondiagcov_ln_evidence_inv"
             + "_realisations_{}D.dat".format(ndim)
         )
-        np.savetxt(save_name, evidence_inv_summary)
-        evidence_inv_analytic_summary = np.zeros(1)
-        evidence_inv_analytic_summary[0] = np.exp(-ln_evidence_analytic)
+        np.savetxt(save_name, ln_evidence_inv_summary)
+        ln_evidence_inv_analytic_summary = np.zeros(1)
+        ln_evidence_inv_analytic_summary[0] = -ln_evidence_analytic
         save_name = (
             save_name_start
-            + "_gaussian_nondiagcov_evidence_inv"
+            + "_gaussian_nondiagcov_ln_evidence_inv"
             + "_analytic_{}D.dat".format(ndim)
         )
-        np.savetxt(save_name, evidence_inv_analytic_summary)
+        np.savetxt(save_name, ln_evidence_inv_analytic_summary)
 
     created_plots = True
     if created_plots:

--- a/examples/gaussian_nondiagcov.py
+++ b/examples/gaussian_nondiagcov.py
@@ -131,7 +131,7 @@ def run_example(
         # Define the number of dimensions and the mean of the Gaussian
         num_samples = nchains * samples_per_chain
         # Initialize a PRNG key (you can use any valid key)
-        key = jax.random.PRNGKey(0)
+        key = jax.random.PRNGKey(i_realisation)
         mean = jnp.zeros(ndim)
 
         # Generate random samples from the 2D Gaussian distribution

--- a/examples/plot_realisations.py
+++ b/examples/plot_realisations.py
@@ -4,6 +4,92 @@ import argparse
 import os
 import ex_utils
 
+def plot_realisations(
+    mc_estimates, std_estimated, analytic_val=None, analytic_text=None
+):
+    """
+    Violin plot of estimated quantity from Monte Carlo (MC) simulations,
+    compared with error bar from estimated standard deviation.
+
+    Also plot analytic value if specified.
+
+    Args:
+        - mc_estimates:
+            1D array of quanties estimate many times by MC simulation.
+        - std_estimate:
+            Standard deviation estimate to be compared with standard deviation
+            from MC simulations.
+        - analytic_val:
+            Plot horizonal line if analytic value of quantity estimated is
+            provided.
+        - analytic_text:
+            Text to include next to line specifying analytic value, if provided.
+
+    Returns:
+        - ax:
+            Plot axis.
+    """
+
+    mean = np.mean(mc_estimates)
+    std_measured = np.std(mc_estimates)
+
+    plot_aspect_ratio = 1.33
+    plot_x_size = 9
+
+    fig, ax = plt.subplots(figsize=(plot_x_size, plot_x_size / plot_aspect_ratio))
+
+    ax.violinplot(
+        mc_estimates,
+        showmeans=False,
+        showmedians=False,
+        showextrema=True,
+        bw_method=1.0,
+    )
+
+    if analytic_val is not None:
+        plt.plot(np.arange(4), np.zeros(4) + analytic_val, "r--")
+        ymin, ymax = ax.get_ylim()
+        ax.text(1.8, analytic_val + (ymax - ymin) * 0.03, analytic_text, color="red")
+
+    plt.errorbar(
+        np.zeros(1) + 1.0,
+        mean,
+        yerr=std_measured,
+        fmt="--o",
+        color="C4",
+        capsize=7,
+        capthick=3,
+        linewidth=3,
+        elinewidth=3,
+    )
+    plt.errorbar(
+        np.zeros(1) + 1.5,
+        mean,
+        yerr=std_estimated,
+        fmt="--o",
+        color="C2",
+        capsize=7,
+        capthick=3,
+        linewidth=3,
+        elinewidth=3,
+    )
+
+    #ymin, ymax = ax.get_ylim()
+    #print("ymim = {}, ymax = {}".format(ymin, ymax))
+    #if ymin < 0:
+    #    ymin = 0
+    #ax.set_ylim([ymin, ymax])
+
+    ax.get_xaxis().set_tick_params(direction="out")
+    ax.xaxis.set_ticks_position("bottom")
+    ax.set_xticks([1.0, 1.5])
+    ax.set_xticklabels(["Measured", "Estimated"])
+
+    ax.set_xlim([0.5, 2.0])
+
+    return ax
+
+
 savefigs = True
 
 # Parse arguments.
@@ -27,21 +113,31 @@ args = parser.parse_args()
 # Load data.
 evidence_inv_summary = np.loadtxt(args.filename_realisations)
 evidence_inv_realisations = evidence_inv_summary[:, 0]
-evidence_inv_var_realisations = evidence_inv_summary[:, 1]
-evidence_inv_var_var_realisations = evidence_inv_summary[:, 2]
+evidence_inv_std_neg_realisations = evidence_inv_summary[:, 1]
+evidence_inv_std_pos_realisations = evidence_inv_summary[:, 2]
+evidence_inv_var_realisations = evidence_inv_summary[:, 3]
+evidence_inv_var_var_realisations = evidence_inv_summary[:, 4]
+
+#evidence_inv_var_realisations =(evidence_inv_std_neg_realisations**2 + evidence_inv_std_pos_realisations**2) *0.5
+
+print("Estimated errors:", evidence_inv_var_realisations)
+print("Mean estimate:", np.mean(evidence_inv_realisations), "+-", np.std(evidence_inv_realisations))
 
 evidence_inv_analytic = np.loadtxt(args.filename_analytic)
+print("Analytic:", evidence_inv_analytic)
 
 # Plot inverse evidence.
 plt.rcParams.update({"font.size": 20})
-ax = ex_utils.plot_realisations(
+ax = plot_realisations(
     mc_estimates=evidence_inv_realisations,
-    std_estimated=np.sqrt(np.mean(evidence_inv_var_realisations)),
+    #std_estimated=np.sqrt(np.mean(evidence_inv_var_realisations)),
+    #std_estimated = [[np.mean(-evidence_inv_std_neg_realisations)], [np.mean(evidence_inv_std_pos_realisations)]],
+    std_estimated = [[-evidence_inv_std_neg_realisations[1]], [evidence_inv_std_pos_realisations[1]]],
     analytic_val=evidence_inv_analytic,
     analytic_text=r"Truth",
 )
 plt.ticklabel_format(style="sci", axis="y", scilimits=(0, 0))
-ax.set_ylabel(r"Inverse evidence ($\rho$)")
+ax.set_ylabel(r"Log inverse evidence ($\ln \rho$)")
 # ax.set_ylim([0.0, 0.01])
 
 filename_base = os.path.basename(args.filename_realisations)
@@ -53,9 +149,10 @@ if savefigs:
     )
 
 # Plot variance of inverse evidence.
-ax = ex_utils.plot_realisations(
+ax = plot_realisations(
     mc_estimates=evidence_inv_var_realisations,
-    std_estimated=np.sqrt(np.mean(evidence_inv_var_var_realisations)),
+    #std_estimated=np.sqrt(np.mean(evidence_inv_var_var_realisations)),
+    std_estimated=np.exp(evidence_inv_var_var_realisations[0])
 )
 plt.ticklabel_format(style="sci", axis="y", scilimits=(0, 0))
 ax.set_ylabel(r"Inverse evidence variance ($\sigma^2$)")

--- a/examples/rosenbrock.py
+++ b/examples/rosenbrock.py
@@ -4,6 +4,8 @@ import time
 import matplotlib.pyplot as plt
 from functools import partial
 import harmonic as hm
+import harmonic.logs as lg
+from scipy.optimize import rosen
 
 
 def ln_prior_uniform(x, xmin=-10.0, xmax=10.0, ymin=-5.0, ymax=15.0):
@@ -82,6 +84,21 @@ def ln_likelihood(x, a=1.0, b=100.0):
     return -f
 
 
+def filter_outside_unit(x, log_l):
+    # if x.ndim == 2:
+    #    log_l = np.where(np.any((x < 0) | (x > 1), axis=-1), -np.inf, log_l)
+    if np.any(x < 0) or np.any(x > 1):
+        log_l = -np.inf
+    return log_l
+
+
+def rosenbrock_likelihood(x):
+
+    log_l = -rosen((x.T - 0.5) * 10)
+
+    return filter_outside_unit(x, log_l)
+
+
 def ln_posterior(x, ln_prior, a=1.0, b=100.0):
     """Compute log_e of posterior.
 
@@ -101,7 +118,8 @@ def ln_posterior(x, ln_prior, a=1.0, b=100.0):
 
     """
 
-    ln_L = ln_likelihood(x, a=a, b=b)
+    # ln_L = ln_likelihood(x, a=a, b=b)
+    ln_L = rosenbrock_likelihood(x)
 
     if not np.isfinite(ln_L):
         return -np.inf
@@ -129,8 +147,8 @@ def run_example(
         plot_corner: Plot marginalised distributions if true.
     """
 
-    if ndim != 2:
-        raise ValueError("Only ndim=2 is supported (ndim={} specified)".format(ndim))
+    # if ndim != 2:
+    #    raise ValueError("Only ndim=2 is supported (ndim={} specified)".format(ndim))
 
     # ===========================================================================
     # Configure Parameters.
@@ -143,16 +161,23 @@ def run_example(
     b = 100.0
 
     # Beginning of path where plots will be saved
-    save_name_start = "examples/plots/" + flow_type
+    save_name_start = "examples/plots/" + flow_type + "_" + str(ndim) + "D"
 
     if flow_type == "RealNVP":
         epochs_num = 8
     elif flow_type == "RQSpline":
-        epochs_num = 5
+        # epochs_num = 5
+        epochs_num = 50
 
     temperature = 0.8
     training_proportion = 0.5
     standardize = True
+    # Spline params
+    n_layers = 5
+    n_bins = 5
+    hidden_size = [32, 32]
+    spline_range = (-10.0, 10.0)
+
     """
     Set prior parameters.
     """
@@ -181,8 +206,8 @@ def run_example(
     """
     Set up and run multiple simulations
     """
-    n_realisations = 1
-    evidence_inv_summary = np.zeros((n_realisations, 3))
+    n_realisations = 2
+    ln_evidence_inv_summary = np.zeros((n_realisations, 5))
     for i_realisation in range(n_realisations):
         if n_realisations > 1:
             hm.logs.info_log(
@@ -229,9 +254,15 @@ def run_example(
             )
         if flow_type == "RQSpline":
             model = hm.model.RQSplineModel(
-                ndim, standardize=standardize, temperature=temperature
+                ndim,
+                n_layers=n_layers,
+                n_bins=n_bins,
+                hidden_size=hidden_size,
+                spline_range=spline_range,
+                standardize=standardize,
+                temperature=temperature,
             )
-        model.fit(chains_train.samples, epochs=epochs_num)
+        model.fit(chains_train.samples, epochs=epochs_num, verbose=True)
 
         # =======================================================================
         # Computing evidence using learnt model and emcee chains
@@ -244,6 +275,7 @@ def run_example(
         ev = hm.Evidence(chains_test.nchains, model)
         ev.add_chains(chains_test)
         ln_evidence, ln_evidence_std = ev.compute_ln_evidence()
+        err_ln_inv_evidence = ev.compute_ln_inv_evidence_errors()
 
         # Compute analytic evidence.
         if ndim == 2:
@@ -262,56 +294,33 @@ def run_example(
             dy = y_grid[1, 0] - y_grid[0, 0]
             evidence_numerical_integration = np.sum(np.exp(ln_posterior_grid)) * dx * dy
 
-        # ======================================================================
-        # Display evidence computation results.
-        # ======================================================================
-        hm.logs.debug_log(
-            "Evidence: numerical = {}, estimate = {}".format(
-                evidence_numerical_integration, np.exp(ln_evidence)
+            # ======================================================================
+            # Display evidence computation results.
+            # ======================================================================
+            hm.logs.debug_log(
+                "Evidence: numerical = {}, estimate = {}".format(
+                    evidence_numerical_integration, np.exp(ln_evidence)
+                )
             )
-        )
-        hm.logs.debug_log(
-            "Evidence: std = {}, std / estimate = {}".format(
-                np.exp(ln_evidence_std), np.exp(ln_evidence_std - ln_evidence)
-            )
-        )
-        diff = np.log(np.abs(evidence_numerical_integration - np.exp(ln_evidence)))
-        hm.logs.info_log(
-            "Evidence: |numerical - estimate| / estimate = {}".format(
-                np.exp(diff - ln_evidence)
-            )
-        )
 
-        # ======================================================================
-        # Display inverse evidence computation results.
-        # ======================================================================
-        hm.logs.debug_log(
-            "Inv Evidence: numerical = {}, estimate = {}".format(
-                1.0 / evidence_numerical_integration, ev.evidence_inv
+            hm.logs.debug_log(
+                "Inv Evidence: numerical = {}, estimate = {}".format(
+                    1.0 / evidence_numerical_integration, ev.evidence_inv
+                )
             )
-        )
-        hm.logs.debug_log(
-            "Inv Evidence: std = {}, std / estimate = {}".format(
-                np.sqrt(ev.evidence_inv_var),
-                np.sqrt(ev.evidence_inv_var) / ev.evidence_inv,
+            diff = np.log(np.abs(evidence_numerical_integration - np.exp(ln_evidence)))
+            hm.logs.info_log(
+                "Evidence: |numerical - estimate| / estimate = {}".format(
+                    np.exp(diff - ln_evidence)
+                )
             )
-        )
-        hm.logs.debug_log(
-            "Inv Evidence: kurtosis = {}, sqrt( 2 / ( n_eff - 1 ) ) = {}".format(
-                ev.kurtosis, np.sqrt(2.0 / (ev.n_eff - 1))
+
+            hm.logs.info_log(
+                "Inv Evidence: |numerical - estimate| / estimate = {}".format(
+                    np.abs(1.0 / evidence_numerical_integration - ev.evidence_inv)
+                    / ev.evidence_inv
+                )
             )
-        )
-        hm.logs.debug_log(
-            "Inv Evidence: sqrt( var(var) )/ var = {}".format(
-                np.sqrt(ev.evidence_inv_var_var) / ev.evidence_inv_var
-            )
-        )
-        hm.logs.info_log(
-            "Inv Evidence: |numerical - estimate| / estimate = {}".format(
-                np.abs(1.0 / evidence_numerical_integration - ev.evidence_inv)
-                / ev.evidence_inv
-            )
-        )
 
         # ===========================================================================
         # Display more technical details
@@ -341,6 +350,43 @@ def run_example(
             "nsamples eff per chain = \n{}".format(ev.nsamples_eff_per_chain)
         )
         hm.logs.debug_log("===============================")
+
+        print(
+            "ln_inv_evidence = {} +/- {}".format(
+                ev.ln_evidence_inv, err_ln_inv_evidence
+            )
+        )
+        print(
+            "ln evidence = {} +/- {} {}".format(
+                -ev.ln_evidence_inv, -err_ln_inv_evidence[1], -err_ln_inv_evidence[0]
+            )
+        )
+        print("kurtosis = {}".format(ev.kurtosis), " Aim for ~3.")
+        # print("ln inverse evidence per chain ", ev.ln_evidence_inv_per_chain)
+        # print(
+        #    "Average ln inverse evidence per chain ",#
+        #    np.mean(ev.ln_evidence_inv_per_chain),
+        # )
+        print(
+            "lnargmax",
+            ev.lnargmax,
+            "lnargmin",
+            ev.lnargmin,
+            "lnprobmax",
+            ev.lnprobmax,
+            "lnprobmin",
+            ev.lnprobmin,
+            "lnpredictmax",
+            ev.lnpredictmax,
+            "lnpredictmin",
+            ev.lnpredictmin,
+        )
+        check = np.exp(0.5 * ev.ln_evidence_inv_var_var - ev.ln_evidence_inv_var)
+        print(
+            check,
+            " Aim for sqrt( 2/(n_eff-1) ) = {}".format(np.sqrt(2.0 / (ev.n_eff - 1))),
+        )
+        print("sqrt(evidence_inv_var_var) / evidence_inv_var = {}".format(check))
 
         # Create corner/triangle plot.
         created_plots = False
@@ -378,10 +424,11 @@ def run_example(
 
             created_plots = True
 
-        # Save out realisations for voilin plot.
-        evidence_inv_summary[i_realisation, 0] = ev.evidence_inv
-        evidence_inv_summary[i_realisation, 1] = ev.evidence_inv_var
-        evidence_inv_summary[i_realisation, 2] = ev.evidence_inv_var_var
+        ln_evidence_inv_summary[i_realisation, 0] = ev.ln_evidence_inv
+        ln_evidence_inv_summary[i_realisation, 1] = err_ln_inv_evidence[0]
+        ln_evidence_inv_summary[i_realisation, 2] = err_ln_inv_evidence[1]
+        ln_evidence_inv_summary[i_realisation, 3] = ev.ln_evidence_inv_var
+        ln_evidence_inv_summary[i_realisation, 4] = ev.ln_evidence_inv_var_var
 
     # ===========================================================================
     # End Timer.
@@ -399,7 +446,7 @@ def run_example(
         )
         np.savetxt(
             save_name,
-            evidence_inv_summary,
+            ln_evidence_inv_summary,
         )
         evidence_inv_analytic_summary = np.zeros(1)
         evidence_inv_analytic_summary[0] = 1.0 / evidence_numerical_integration
@@ -417,13 +464,13 @@ def run_example(
 
 if __name__ == "__main__":
     # Setup logging config.
-    hm.logs.setup_logging()
+    lg.setup_logging()
 
     # Define parameters.
-    ndim = 2
+    ndim = 10
     nchains = 200
-    samples_per_chain = 5000
-    nburn = 2000
+    samples_per_chain = 6000
+    nburn = 3000
 
     # flow_str = "RealNVP"
     flow_str = "RQSpline"

--- a/examples/rosenbrock.py
+++ b/examples/rosenbrock.py
@@ -205,7 +205,7 @@ def run_example(
     """
     Set up and run multiple simulations
     """
-    n_realisations = 2
+    n_realisations = 1
     ln_evidence_inv_summary = np.zeros((n_realisations, 5))
     for i_realisation in range(n_realisations):
         if n_realisations > 1:
@@ -300,15 +300,22 @@ def run_example(
             # ======================================================================
             # Display evidence computation results.
             # ======================================================================
-            hm.logs.debug_log(
+            hm.logs.info_log(
                 "Evidence: numerical = {}, estimate = {}".format(
                     evidence_numerical_integration, np.exp(ln_evidence)
                 )
             )
 
+            hm.logs.info_log(
+                "Ln evidence numerical = {}".format(
+                    np.log(evidence_numerical_integration)
+                )
+            )
+
             hm.logs.debug_log(
                 "Inv Evidence: numerical = {}, estimate = {}".format(
-                    1.0 / evidence_numerical_integration, ev.evidence_inv
+                    1.0 / evidence_numerical_integration,
+                    np.exp(ev.ln_evidence_inv),
                 )
             )
             diff = np.log(np.abs(evidence_numerical_integration - np.exp(ln_evidence)))
@@ -320,8 +327,11 @@ def run_example(
 
             hm.logs.info_log(
                 "Inv Evidence: |numerical - estimate| / estimate = {}".format(
-                    np.abs(1.0 / evidence_numerical_integration - ev.evidence_inv)
-                    / ev.evidence_inv
+                    np.abs(
+                        1.0 / evidence_numerical_integration
+                        - np.exp(ev.ln_evidence_inv)
+                    )
+                    / np.exp(ev.ln_evidence_inv)
                 )
             )
 
@@ -472,10 +482,10 @@ if __name__ == "__main__":
     lg.setup_logging()
 
     # Define parameters.
-    ndim = 10
-    nchains = 1000
-    samples_per_chain = 10e6
-    nburn = 10000
+    ndim = 2
+    nchains = 100
+    samples_per_chain = 5000
+    nburn = 1000
 
     # flow_str = "RealNVP"
     flow_str = "RQSpline"

--- a/harmonic/evidence.py
+++ b/harmonic/evidence.py
@@ -251,7 +251,7 @@ class Evidence:
         Y = chains.ln_posterior
         nchains = self.nchains
 
-        if not num_slices is None:
+        if num_slices is not None:
             if num_slices > X.shape[0]:
                 raise ValueError(
                     "Can't split chains into more blocks than there are samples."


### PR DESCRIPTION
- Add functionality to batch samples for evidence estimation in  the `add_chains` method to avoid memory issues.

- Change Rosenbrock example to be able to handle arbitrary dimension and fix bugs.

- Switch Gaussian example and plotting of realisations to log space.
