### PR TITLE
Save Rosenbrock analytical evidence in log space

### DIFF
--- a/examples/rosenbrock.py
+++ b/examples/rosenbrock.py
@@ -205,7 +205,7 @@ def run_example(
     """
     Set up and run multiple simulations
     """
-    n_realisations = 1
+    n_realisations = 100
     ln_evidence_inv_summary = np.zeros((n_realisations, 5))
     for i_realisation in range(n_realisations):
         if n_realisations > 1:
@@ -453,7 +453,7 @@ def run_example(
     if n_realisations > 1:
         save_name = (
             save_name_start
-            + "_rosenbrock_evidence_inv_T"
+            + "_rosenbrock_evidence_log_inv_T"
             + str(temperature)
             + "_realisations.dat"
         )
@@ -464,8 +464,8 @@ def run_example(
 
         if ndim == 2:
             evidence_inv_analytic_summary = np.zeros(1)
-            evidence_inv_analytic_summary[0] = 1.0 / evidence_numerical_integration
-            save_name = save_name_start + "_rosenbrock_evidence_inv" + "_analytic.dat"
+            evidence_inv_analytic_summary[0] = -np.log(evidence_numerical_integration)
+            save_name = save_name_start + "_rosenbrock_evidence_log_inv" + "_analytic.dat"
             np.savetxt(
                 save_name,
                 evidence_inv_analytic_summary,

--- a/examples/rosenbrock.py
+++ b/examples/rosenbrock.py
@@ -166,14 +166,14 @@ def run_example(
         epochs_num = 8
     elif flow_type == "RQSpline":
         # epochs_num = 5
-        epochs_num = 50
+        epochs_num = 10
 
     temperature = 0.8
     training_proportion = 0.5
     standardize = True
     # Spline params
-    n_layers = 5
-    n_bins = 5
+    n_layers = 3
+    n_bins = 8
     hidden_size = [32, 32]
     spline_range = (-10.0, 10.0)
 
@@ -205,7 +205,7 @@ def run_example(
     """
     Set up and run multiple simulations
     """
-    n_realisations = 100
+    n_realisations = 50
     ln_evidence_inv_summary = np.zeros((n_realisations, 5))
     for i_realisation in range(n_realisations):
         if n_realisations > 1:
@@ -489,7 +489,7 @@ if __name__ == "__main__":
 
     # flow_str = "RealNVP"
     flow_str = "RQSpline"
-    np.random.seed(20)
+    np.random.seed(2)
 
     hm.logs.info_log("Rosenbrock example")
 

--- a/tests/test_flow_model.py
+++ b/tests/test_flow_model.py
@@ -179,8 +179,8 @@ def test_flows_normalization(model, var):
     num_samples_int = 200000
     shape = (num_samples_int, ndim)
     # Draw samples from uniform distribution -3 to 3 standard deviations away from mean
-    minval = -4 * var**0.5
-    maxval = 4 * var**0.5
+    minval = -3 * var**0.5
+    maxval = 3 * var**0.5
     uniform_samples = jax.random.uniform(
         jax.random.PRNGKey(0), shape=shape, minval=minval, maxval=maxval
     )

--- a/tests/test_flow_model.py
+++ b/tests/test_flow_model.py
@@ -176,7 +176,7 @@ def test_flows_normalization(model, var):
     model.temperature = 1.0
 
     # MC integral of the flow
-    num_samples_int = 100000
+    num_samples_int = 200000
     shape = (num_samples_int, ndim)
     # Draw samples from uniform distribution -3 to 3 standard deviations away from mean
     minval = -4 * var**0.5

--- a/tests/test_flow_model.py
+++ b/tests/test_flow_model.py
@@ -176,11 +176,11 @@ def test_flows_normalization(model, var):
     model.temperature = 1.0
 
     # MC integral of the flow
-    num_samples_int = 50000
+    num_samples_int = 100000
     shape = (num_samples_int, ndim)
     # Draw samples from uniform distribution -3 to 3 standard deviations away from mean
-    minval = -3 * var**0.5
-    maxval = 3 * var**0.5
+    minval = -4 * var**0.5
+    maxval = 4 * var**0.5
     uniform_samples = jax.random.uniform(
         jax.random.PRNGKey(0), shape=shape, minval=minval, maxval=maxval
     )
@@ -227,7 +227,7 @@ def test_flows_gaussian(model):
 
     model.fit(samples, epochs=epochs, verbose=True)
 
-    nsamples = 5000
+    nsamples = 10000
     model.temperature = 1.0
     flow_samples = model.sample(nsamples)
     sample_var = jnp.var(flow_samples, axis=0)


### PR DESCRIPTION
- Change analytical evidence file saving for Rosenbrock to log space to be compatible to be read in for [`plot_realisations()`](https://github.com/astro-informatics/harmonic/blob/bugfix/rosenbrock_save_logspace/examples/plot_realisations.py#L7)
- Change some hyperparameters to values that work well with the 2D case
- Change number of samples in numerical integrals in tests to get a more accurate value 